### PR TITLE
Add /review-pr slash command

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -640,6 +640,59 @@ export default function TerminalChatInput({
         }
 
         return;
+      } else if (inputValue.startsWith("/review-pr")) {
+        setInput("");
+
+        const match = inputValue.match(/\/review-pr\s+#?(\d+)/);
+        if (!match) {
+          setItems((prev) => [
+            ...prev,
+            {
+              id: `reviewpr-usage-${Date.now()}`,
+              type: "message",
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text: "Usage: /review-pr #<number>",
+                },
+              ],
+            },
+          ]);
+          return;
+        }
+
+        try {
+          const { fetchPrDiff } = await import("../../utils/review-pr.js");
+          const diff = await fetchPrDiff(Number(match[1]));
+
+          setItems((prev) => [
+            ...prev,
+            {
+              id: `reviewpr-${Date.now()}`,
+              type: "message",
+              role: "system",
+              content: [{ type: "input_text", text: diff }],
+            },
+          ]);
+        } catch (error) {
+          setItems((prev) => [
+            ...prev,
+            {
+              id: `reviewpr-error-${Date.now()}`,
+              type: "message",
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text: `⚠️ Failed to fetch PR: ${error}`,
+                },
+              ],
+            },
+          ]);
+        }
+
+        return;
       } else if (inputValue.startsWith("/")) {
         // Handle invalid/unrecognized commands. Only single-word inputs starting with '/'
         // (e.g., /command) that are not recognized are caught here. Any other input, including

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -60,6 +60,9 @@ export default function HelpOverlay({
           <Text color="cyan">/diff</Text> – view working tree git diff
         </Text>
         <Text>
+          <Text color="cyan">/review-pr</Text> – review a GitHub pull request
+        </Text>
+        <Text>
           <Text color="cyan">/compact</Text> – condense context into a summary
         </Text>
 

--- a/codex-cli/src/utils/review-pr.ts
+++ b/codex-cli/src/utils/review-pr.ts
@@ -1,0 +1,33 @@
+import { execSync } from "node:child_process";
+
+/** Retrieve the owner/repo slug from git remote URL. */
+function getRepoSlug(): string | null {
+  try {
+    const remote = execSync("git config --get remote.origin.url", {
+      encoding: "utf8",
+    }).trim();
+
+  const match = remote.match(/github\.com[:/](.+)\.git$/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/** Fetch diff text for a given PR number from GitHub. */
+export async function fetchPrDiff(pr: number): Promise<string> {
+  const slug = getRepoSlug();
+  if (!slug) {
+    throw new Error("Not a GitHub repository");
+  }
+
+  const url = `https://patch-diff.githubusercontent.com/raw/${slug}/pull/${pr}.diff`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch diff: ${res.status}`);
+  }
+  return res.text();
+}

--- a/codex-cli/src/utils/slash-commands.ts
+++ b/codex-cli/src/utils/slash-commands.ts
@@ -33,4 +33,8 @@ export const SLASH_COMMANDS: Array<SlashCommand> = [
     description:
       "Show git diff of the working directory (or applied patches if not in git)",
   },
+  {
+    command: "/review-pr",
+    description: "Review code from a GitHub pull request (e.g. /review-pr #10)",
+  },
 ];

--- a/codex-cli/tests/slash-commands.test.ts
+++ b/codex-cli/tests/slash-commands.test.ts
@@ -12,6 +12,7 @@ test("SLASH_COMMANDS includes expected commands", () => {
   expect(commands).toContain("/approval");
   expect(commands).toContain("/clearhistory");
   expect(commands).toContain("/diff");
+  expect(commands).toContain("/review-pr");
 });
 
 test("filters slash commands by prefix", () => {


### PR DESCRIPTION
## Summary
- add `/review-pr` command for fetching GitHub pull request diffs
- expose command in help overlay and autocompletion
- implement fetch logic in new utility
- test command registration

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686119b3eac4832884becd25d1611778